### PR TITLE
Add dataset fld

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Datasets implemented in LogiTorch:
 - [x] [PARARULES Plus](https://github.com/Strong-AI-Lab/PARARULE-Plus) <sub>(MIT LICENSE)</sub>
 - [x] [AbductionRules](https://arxiv.org/abs/2203.12186) <sub>(MIT LICENSE)</sub>
 - [x] [FOLIO](https://arxiv.org/abs/2209.00840) <sub>(CC-BY-SA-4.0 LICENSE)</sub>
+- [x] [FLD](https://proceedings.mlr.press/v202/morishita23a.html)  <sub>(CC-BY-SA-4.0 LICENSE)</sub>
 - [ ] [LogiQA2.0](https://arxiv.org/abs/2007.08124)
 - [ ] [LogiQA20 NLI](https://arxiv.org/abs/2007.08124) 
 - [ ] [HELP](https://aclanthology.org/S19-1027.pdf) 

--- a/examples/eval_examples.py
+++ b/examples/eval_examples.py
@@ -115,7 +115,7 @@ elif MODEL == "FLD":
     model.to(DEVICE)
     model.eval()
 
-    test_dataset = FLDDataset("hitachi-nlp/FLD.v2", "test", "proof_generation_all", max_samples=10)
+    test_dataset = FLDDataset("FLD.v2", "test", "proof_generation_all", max_samples=10)
 
     # fld_metrics = load('/home/acb11878tj/work/projects/FLD-metrics/FLD_metrics.py')
     fld_metrics = load('hitachi-nlp/FLD_metrics')

--- a/examples/eval_examples.py
+++ b/examples/eval_examples.py
@@ -23,11 +23,8 @@ from logitorch.pl_models.fld import PLFLDAllAtOnceProver
 from logitorch.pl_models.ruletaker import PLRuleTaker
 from evaluate import load
 
-# MODEL = "ruletaker"
-# DEVICE = "cpu"
-
-MODEL = "FLD"
-DEVICE = "cuda"
+MODEL = "ruletaker"
+DEVICE = "cpu"
 
 
 def parse_facts_rules(facts, rules):
@@ -117,20 +114,11 @@ elif MODEL == "FLD":
 
     test_dataset = FLDDataset("FLD.v2", "test", "proof_generation_all", max_samples=10)
 
-    # fld_metrics = load('/home/acb11878tj/work/projects/FLD-metrics/FLD_metrics.py')
     fld_metrics = load('hitachi-nlp/FLD_metrics')
 
     metrics = defaultdict(list)
     for i in tqdm(test_dataset):
         pred = model.predict(i['prompt_serial'], device=DEVICE)
-
-        # from FLD_task import log_example
-        # log_example(
-        #     context=i['context'],
-        #     hypothesis=i['hypothesis'],
-        #     gold_proofs=[i['proof_serial']],
-        #     pred_proof=pred,
-        # )
 
         _metrics = fld_metrics.compute(
             predictions=[pred],

--- a/examples/training_examples.py
+++ b/examples/training_examples.py
@@ -38,10 +38,10 @@ def main():
         # model_name = "google/t5-v1_1-large"
         model_name = "t5-base"
 
-        max_train_samples = 1
+        max_train_samples = 10
         train_dataset = FLDDataset(dataset_name, "train", task, max_samples=max_train_samples)
 
-        max_val_samples = 1
+        max_val_samples = 10
         val_dataset = FLDDataset(dataset_name, "val", task, max_samples=max_val_samples)
 
         checkpoint_callback = ModelCheckpoint(
@@ -63,8 +63,8 @@ def main():
         )
 
         train_effective_batch_size = 64
-        train_batch_size = 8
-        eval_batch_size = 8
+        train_batch_size = 4
+        eval_batch_size = 4
         train_dataloader = DataLoader(train_dataset, train_batch_size, collate_fn=fld_collator)
         val_dataloader = DataLoader(val_dataset, eval_batch_size, collate_fn=fld_collator)
 

--- a/examples/training_examples.py
+++ b/examples/training_examples.py
@@ -38,10 +38,12 @@ def main():
         # model_name = "google/t5-v1_1-large"
         model_name = "t5-base"
 
-        max_train_samples = 10
+        # max_train_samples = 10
+        max_train_samples = None
         train_dataset = FLDDataset(dataset_name, "train", task, max_samples=max_train_samples)
 
-        max_val_samples = 10
+        # jsmax_val_samples = 10
+        max_val_samples = 500
         val_dataset = FLDDataset(dataset_name, "val", task, max_samples=max_val_samples)
 
         checkpoint_callback = ModelCheckpoint(
@@ -54,7 +56,8 @@ def main():
             dirpath="models/",
             filename="best_fld-{epoch:02d}-{val_loss:.2f}",
 
-            every_n_train_steps=100,
+            # every_n_train_steps=100,
+            every_n_train_steps=2500,
             # save_on_train_epoch_end=True,
         )
 
@@ -82,7 +85,8 @@ def main():
             accumulate_grad_batches=accum_steps,
 
             # max_epochs=100,
-            max_steps=5000,
+            # max_steps=5000,
+            max_steps=20000,
         )
 
         trainer.fit(pl_proofwriter, train_dataloader, val_dataloader)

--- a/examples/training_examples.py
+++ b/examples/training_examples.py
@@ -24,11 +24,8 @@ from logitorch.pl_models.fld import PLFLDAllAtOnceProver
 from logitorch.pl_models.prover import PLPRover
 from logitorch.pl_models.ruletaker import PLRuleTaker
 
-# MODEL = "proofwriter"
-# DEVICE = "cpu"
-
-MODEL = "FLD"
-DEVICE = "gpu"
+MODEL = "proofwriter"
+DEVICE = "cpu"
 
 
 def main():
@@ -102,7 +99,6 @@ def main():
             mode="min",
             dirpath="models/",
             filename="best_fld-{epoch:02d}-{val_loss:.2f}",
-            # every_n_train_steps=1000,  # every_n_train_steps requires monitor="train_loss"
         )
 
         fld_collator = FLDProofGenerationAllCollator(
@@ -122,8 +118,6 @@ def main():
             accelerator=DEVICE,
             accumulate_grad_batches=16,
             max_epochs=40,
-            # max_steps=100,
-            # max_steps=20000,
         )
 
         trainer.fit(pl_proofwriter, train_dataloader, val_dataloader)

--- a/examples/training_examples.py
+++ b/examples/training_examples.py
@@ -93,8 +93,8 @@ def main():
         trainer.fit(pl_prover, train_dataloader, val_dataloader)
 
     elif MODEL == "FLD":
-        train_dataset = FLDDataset("hitachi-nlp/FLD.v2", "train", "proof_generation_all")
-        val_dataset = FLDDataset("hitachi-nlp/FLD.v2", "val", "proof_generation_all", max_samples=100)
+        train_dataset = FLDDataset("FLD.v2", "train", "proof_generation_all")
+        val_dataset = FLDDataset("FLD.v2", "val", "proof_generation_all", max_samples=100)
 
         checkpoint_callback = ModelCheckpoint(
             save_top_k=1,

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     textblob~=0.17.0
     nltk~=3.7.0
     protobuf==3.20.0
-    datasets==2.10.1
+    datasets==2.14.5
     evaluate==0.4.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     textblob~=0.17.0
     nltk~=3.7.0
     protobuf==3.20.0
+    datasets==2.10.1
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     nltk~=3.7.0
     protobuf==3.20.0
     datasets==2.10.1
+    evaluate==0.4.0
 
 [options.extras_require]
 dev =

--- a/src/logitorch/data_collators/fld_collator.py
+++ b/src/logitorch/data_collators/fld_collator.py
@@ -40,12 +40,10 @@ class FLDProofGenerationAllCollator:
         ys: List[str] = []
         for i_example, example in enumerate(batch):
             prompt = example['prompt_serial']
-            partial_proof = example['partial_proof_serial'] or ''
-            next_step = example['next_proof_step_serial']
             gold_proof = example['proof_serial']
 
-            x = prompt + partial_proof
-            y = next_step
+            x = prompt
+            y = gold_proof
             xs.append(x)
             ys.append(y)
             if self.log_examples:

--- a/src/logitorch/data_collators/fld_collator.py
+++ b/src/logitorch/data_collators/fld_collator.py
@@ -36,30 +36,33 @@ class FLDProofGenerationAllCollator:
         the output tensor.
         """
 
-        prompts: List[str] = []
-        proof_steps: List[str] = []
+        xs: List[str] = []
+        ys: List[str] = []
         for i_example, example in enumerate(batch):
-            prompt = example['context']
-            next_step = example['next_step']
-            gold_proof = example['gold_proof']
+            prompt = example['prompt_serial']
+            partial_proof = example['partial_proof_serial'] or ''
+            next_step = example['next_proof_step_serial']
+            gold_proof = example['proof_serial']
 
-            prompts.append(prompt)
-            proof_steps.append(next_step)
+            x = prompt + partial_proof
+            y = next_step
+            xs.append(x)
+            ys.append(y)
             if self.log_examples:
                 logger.info('----------------- collate example = [%d]', i_example)
-                logger.info('prompt     : "%s"', prompt)
-                logger.info('next_step  : "%s"', next_step)
+                logger.info('x     : "%s"', x)
+                logger.info('y  : "%s"', y)
                 logger.info('gold_proof : "%s"', gold_proof)
 
         batch_x = self.tokenizer(
-            text=prompts,
+            text=xs,
             padding=True,
             return_tensors="pt",
             max_length=self.max_src_length,
             truncation=True,
         )
         batch_y = self.tokenizer(
-            proof_steps,
+            ys,
             padding=True,
             return_tensors="pt",
             max_length=self.max_tgt_length,

--- a/src/logitorch/data_collators/fld_collator.py
+++ b/src/logitorch/data_collators/fld_collator.py
@@ -1,6 +1,5 @@
 from typing import Dict, Tuple, List, Any, Tuple
 import logging
-import random
 
 import torch
 from transformers import T5Tokenizer
@@ -14,28 +13,13 @@ class FLDProofGenerationAllCollator:
                  pretrained_t5_tokenizer: str,
                  max_src_length=1024,
                  max_tgt_length=512,
-                 log_examples=True) -> None:
-        """
-        It takes in a pretrained T5 tokenizer
-
-        :param pretrained_t5_tokenizer: The name of the T5 tokenizer to use
-        :type pretrained_t5_tokenizer: str
-        """
+                 log_examples=False) -> None:
         self.tokenizer = T5Tokenizer.from_pretrained(pretrained_t5_tokenizer)
         self.log_examples = log_examples
         self.max_src_length = max_src_length
         self.max_tgt_length = max_tgt_length
 
     def __call__(self, batch: List[Dict]) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
-        """
-        The function takes in a batch of data, and returns a tuple of two elements: a dictionary of
-        tensors, and a tensor
-
-        :param batch: A list of tuples of the form (context, question, label, proof)
-        :return: A tuple of two tensors. The first tensor is the input tensor, and the second tensor is
-        the output tensor.
-        """
-
         xs: List[str] = []
         ys: List[str] = []
         for i_example, example in enumerate(batch):

--- a/src/logitorch/data_collators/fld_collator.py
+++ b/src/logitorch/data_collators/fld_collator.py
@@ -1,0 +1,69 @@
+from typing import Dict, Tuple, List, Any, Tuple
+import logging
+import random
+
+import torch
+from transformers import T5Tokenizer
+
+
+logger = logging.getLogger(__name__)
+
+
+class FLDProofGenerationAllCollator:
+    def __init__(self,
+                 pretrained_t5_tokenizer: str,
+                 max_src_length=1024,
+                 max_tgt_length=512,
+                 log_examples=True) -> None:
+        """
+        It takes in a pretrained T5 tokenizer
+
+        :param pretrained_t5_tokenizer: The name of the T5 tokenizer to use
+        :type pretrained_t5_tokenizer: str
+        """
+        self.tokenizer = T5Tokenizer.from_pretrained(pretrained_t5_tokenizer)
+        self.log_examples = log_examples
+        self.max_src_length = max_src_length
+        self.max_tgt_length = max_tgt_length
+
+    def __call__(self, batch: List[Dict]) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
+        """
+        The function takes in a batch of data, and returns a tuple of two elements: a dictionary of
+        tensors, and a tensor
+
+        :param batch: A list of tuples of the form (context, question, label, proof)
+        :return: A tuple of two tensors. The first tensor is the input tensor, and the second tensor is
+        the output tensor.
+        """
+
+        prompts: List[str] = []
+        proof_steps: List[str] = []
+        for i_example, example in enumerate(batch):
+            prompt = example['context']
+            next_step = example['next_step']
+            gold_proof = example['gold_proof']
+
+            prompts.append(prompt)
+            proof_steps.append(next_step)
+            if self.log_examples:
+                logger.info('----------------- collate example = [%d]', i_example)
+                logger.info('prompt     : "%s"', prompt)
+                logger.info('next_step  : "%s"', next_step)
+                logger.info('gold_proof : "%s"', gold_proof)
+
+        batch_x = self.tokenizer(
+            text=prompts,
+            padding=True,
+            return_tensors="pt",
+            max_length=self.max_src_length,
+            truncation=True,
+        )
+        batch_y = self.tokenizer(
+            proof_steps,
+            padding=True,
+            return_tensors="pt",
+            max_length=self.max_tgt_length,
+            truncation=True,
+        )
+
+        return batch_x, batch_y.input_ids

--- a/src/logitorch/datasets/base.py
+++ b/src/logitorch/datasets/base.py
@@ -55,5 +55,7 @@ class AbstractProofQADataset(BaseLogicDataset):
         Tuple[Dict[str, str], Dict[str, str], List[str], List[str], List[str]],
         Tuple[Dict[str, str], Dict[str, str], List[str], List[str]],
         Tuple[Dict[str, str], Dict[str, str], List[str]],
+
+        Tuple[str, str, str, str, int],  # FLD dataset
     ]:
         raise NotImplementedError()

--- a/src/logitorch/datasets/base.py
+++ b/src/logitorch/datasets/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Optional
 
 from torch.utils.data import Dataset
 
@@ -55,7 +55,6 @@ class AbstractProofQADataset(BaseLogicDataset):
         Tuple[Dict[str, str], Dict[str, str], List[str], List[str], List[str]],
         Tuple[Dict[str, str], Dict[str, str], List[str], List[str]],
         Tuple[Dict[str, str], Dict[str, str], List[str]],
-
-        Tuple[str, str, str, str, int],  # FLD dataset
+        Dict[str, Union[Optional[str], Optional[int]]],
     ]:
         raise NotImplementedError()

--- a/src/logitorch/datasets/proof_qa/fld_dataset.py
+++ b/src/logitorch/datasets/proof_qa/fld_dataset.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union, Any
+from typing import Dict, List, Optional, Tuple, Union
 
 from logitorch.datasets.base import AbstractProofQADataset
 from logitorch.datasets.exceptions import (
@@ -15,9 +15,6 @@ FLD_SUB_DATASETS = [
 ]
 FLD_TASKS = [
     "proof_generation_all",
-    # "proof_generation_iter",
-    # "implication_enumeration",
-    # "abduction",
 ]
 
 
@@ -45,7 +42,7 @@ class FLDDataset(AbstractProofQADataset):
             self.split_set = split_set
             self.task = task
 
-            hf_split = 'validation' if split_set == 'dev' else split_set
+            hf_split = "validation" if split_set == "dev" else split_set
             hf_dataset = load_dataset(
                 dataset_name,
                 split=hf_split,
@@ -81,8 +78,7 @@ class FLDDataset(AbstractProofQADataset):
         Tuple[Dict[str, str], Dict[str, str], List[str], List[str], List[str]],
         Tuple[Dict[str, str], Dict[str, str], List[str], List[str]],
         Tuple[Dict[str, str], Dict[str, str], List[str]],
-
-        Dict[str, Any],  # FLD dataset
+        Dict[str, Union[Optional[str], Optional[int]]],
     ]:
         return self._hf_dataset[index]
 
@@ -90,5 +86,4 @@ class FLDDataset(AbstractProofQADataset):
         return f'The {self.split_set} set of {self.dataset_name}\'s FLD for the task of "{self.task}" has {self.__len__()} instances'
 
     def __len__(self) -> int:
-        # return len(self.triples)
         return len(self._hf_dataset)

--- a/src/logitorch/datasets/proof_qa/fld_dataset.py
+++ b/src/logitorch/datasets/proof_qa/fld_dataset.py
@@ -10,8 +10,8 @@ from logitorch.datasets.utils import SPLIT_SETS
 from datasets import load_dataset
 
 FLD_SUB_DATASETS = [
-    "hitachi-nlp/FLD.v2",
-    "hitachi-nlp/FLD_star.v2",
+    "FLD.v2",
+    "FLD_star.v2",
 ]
 FLD_TASKS = [
     "proof_generation_all",
@@ -42,9 +42,14 @@ class FLDDataset(AbstractProofQADataset):
             self.split_set = split_set
             self.task = task
 
+            if dataset_name == "FLD.v2":
+                hf_path, hf_name = "hitachi-nlp/FLD.v2", "default"
+            elif dataset_name == "FLD_star.v2":
+                hf_path, hf_name = "hitachi-nlp/FLD.v2", "star"
             hf_split = "validation" if split_set == "dev" else split_set
             hf_dataset = load_dataset(
-                dataset_name,
+                hf_path,
+                name=hf_name,
                 split=hf_split,
             )
             if max_samples is not None:

--- a/src/logitorch/datasets/proof_qa/fld_dataset.py
+++ b/src/logitorch/datasets/proof_qa/fld_dataset.py
@@ -1,0 +1,151 @@
+from typing import Dict, List, Optional, Tuple, Union, Any
+
+from logitorch.datasets.base import AbstractProofQADataset
+from logitorch.datasets.exceptions import (
+    DatasetNameError,
+    SplitSetError,
+    TaskError,
+)
+from logitorch.datasets.utils import SPLIT_SETS
+from datasets import load_dataset
+from FLD_task import load_deduction
+from FLD_task.hf_dataset import serialize_transform
+
+FLD_SUB_DATASETS = [
+    "hitachi-nlp/FLD.v2",
+    "hitachi-nlp/FLD_star.v2",
+]
+FLD_TASKS = [
+    "proof_generation_all",
+    # "proof_generation_iter",
+    # "implication_enumeration",
+    # "abduction",
+]
+
+
+class FLDDataset(AbstractProofQADataset):
+    def __init__(
+        self,
+        dataset_name: str,
+        split_set: str,
+        task: str,
+        max_samples: Optional[int] = None,
+    ) -> None:
+        try:
+            if dataset_name not in FLD_SUB_DATASETS:
+                raise DatasetNameError()
+
+            if split_set == "val":
+                split_set = "dev"
+            elif split_set not in SPLIT_SETS:
+                raise SplitSetError(SPLIT_SETS)
+
+            if task not in FLD_TASKS:
+                raise TaskError()
+
+            self.dataset_name = dataset_name
+            self.split_set = split_set
+            self.task = task
+
+            hf_split = 'validation' if split_set == 'dev' else split_set
+            hf_dataset = load_dataset(
+                dataset_name,
+                split=hf_split,
+            )
+            # load and dump once to normalize dataset format to the latest version.
+            hf_dataset = hf_dataset.map(
+                lambda example: load_deduction(example).dict(),
+                batched=False,
+            )
+            if max_samples is not None:
+                hf_dataset = hf_dataset.select(range(max_samples))
+            self._hf_dataset = hf_dataset
+
+        except DatasetNameError as err:
+            print(err.message)
+            print(f"The FLD datasets are: {FLD_SUB_DATASETS}")
+            raise err
+        except SplitSetError as err:
+            print(err.message)
+            raise err
+        except TaskError as err:
+            print(err.message)
+            print(f"The FLD tasks are: {FLD_TASKS}")
+            raise err
+
+    def __getitem__(
+        self, index: int
+    ) -> Union[
+        Tuple[
+            Dict[str, str],
+            Dict[str, str],
+            List[str],
+            List[str],
+            List[str],
+            List[str],
+            List[int],
+        ],
+        Tuple[Dict[str, str], Dict[str, str], List[str], List[str], List[str]],
+        Tuple[Dict[str, str], Dict[str, str], List[str], List[str]],
+        Tuple[Dict[str, str], Dict[str, str], List[str]],
+
+        Dict[str, Any],  # FLD dataset
+    ]:
+        batch_example = {
+            'context': [self._hf_dataset[index]['context']],
+            'hypothesis': [self._hf_dataset[index]['hypothesis']],
+            'world_assump_label': [self._hf_dataset[index]['world_assump_label']],
+            'proofs': [self._hf_dataset[index]['proofs']],
+            'original_tree_depth': [self._hf_dataset[index]['original_tree_depth']],
+        }
+
+        if self.task == "proof_generation_all":
+            batch_example = serialize_transform(
+                batch_example,
+                'train',
+                proof_sampling='all_at_once',
+                sample_negative_proof=True,
+            )
+        elif self.task == "proof_generation_iter":
+            pass
+        else:
+            raise ValueError()
+
+        return {
+            key: vals[0]
+            for key, vals in batch_example.items()
+        }
+
+
+    def __str__(self) -> str:
+        return f'The {self.split_set} set of {self.dataset_name}\'s FLD for the task of "{self.task}" has {self.__len__()} instances'
+
+    def __len__(self) -> int:
+        # return len(self.triples)
+        return len(self._hf_dataset)
+
+
+    def _extract_serials(self, examples: Dict[str, List[Any]]) -> Tuple[List[str], List[str], List[str]]:
+        if self.log_examples:
+            logger.info('')
+            logger.info('============================= extract_inputs_targets() =============================')
+
+        inputs: List[str] = []
+        targets: List[str] = []
+        gold_proofs: List[str] = []
+        for i_example in range(len(examples['context'])):
+            context = examples['context'][i_example]
+            next_step = examples['next_step'][i_example]
+            gold_proof = random.choice(examples['gold_proof'][i_example])
+
+            inputs.append(context)
+            targets.append(next_step)
+            gold_proofs.append(gold_proof)
+            if self.log_examples:
+                logger.info('context    [%d] : "%s"', i_example, context)
+                logger.info('next_step [%d] : "%s"', i_example, next_step)
+                logger.info('gold_proof [%d] : "%s"', i_example, gold_proof)
+
+        inputs = [self.prefix + inp for inp in inputs]
+
+        return inputs, targets, gold_proofs

--- a/src/logitorch/datasets/proof_qa/fld_dataset.py
+++ b/src/logitorch/datasets/proof_qa/fld_dataset.py
@@ -95,21 +95,13 @@ class FLDDataset(AbstractProofQADataset):
         hf_example = self._hf_dataset[index]
         deduction = load_deduction(hf_example)
 
-        if self.task == "proof_generation_all":
-            serial = serialize(
-                deduction,
-                stepwise=False,
-                sample_negative_proof=False,
-            )
-        elif self.task == "proof_generation_iter":
-            sample_negative_proof = self.split_set == 'train'
-            serial = serialize(
-                deduction,
-                stepwise=True,
-                sample_negative_proof=sample_negative_proof,
-            )
-        else:
-            raise ValueError()
+        stepwise = self.task == 'proof_generation_iter'
+        sample_negative_proof = self.split_set == 'train' if self.task == 'proof_generation_iter' else False
+        serial = serialize(
+            deduction,
+            stepwise=stepwise,
+            sample_negative_proof=sample_negative_proof,
+        )
 
         hf_example_with_serial = hf_example.copy()
         hf_example_with_serial.update({

--- a/src/logitorch/models/fld.py
+++ b/src/logitorch/models/fld.py
@@ -1,0 +1,47 @@
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+from transformers import T5ForConditionalGeneration, T5Tokenizer
+from transformers.modeling_outputs import SequenceClassifierOutput
+
+
+class FLDSimpleProver(nn.Module):
+    def __init__(self, pretrained_t5_model: str) -> None:
+        super().__init__()
+        self.model = T5ForConditionalGeneration.from_pretrained(pretrained_t5_model)
+        self.tokenizer = T5Tokenizer.from_pretrained(pretrained_t5_model)
+
+    def forward(
+        self, x: Dict[str, torch.Tensor], y: torch.Tensor = None
+    ) -> SequenceClassifierOutput:
+        if y is not None:
+            return self.model(**x, labels=y)
+        return self.model(**x)
+
+    def predict(
+        self,
+        prompt: str,
+        num_beams: int = 5,
+        max_length: int = 1000,
+        device: str = "cpu",
+    ) -> List[str]:
+        with torch.no_grad():
+            tokenized_x = self.tokenizer(
+                prompt, padding=True, return_tensors="pt"
+            )
+
+            beam_output = self.model.generate(
+                **tokenized_x.to(device),
+                max_length=max_length,
+                num_beams=num_beams,
+                do_sample=True,
+                top_p=0.90
+            )
+            pred = self.tokenizer.decode(
+                beam_output[0],
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=True,
+            )
+
+        return pred

--- a/src/logitorch/models/fld.py
+++ b/src/logitorch/models/fld.py
@@ -1,12 +1,17 @@
 from typing import Dict, List
 
 import torch
-import torch.nn as nn
+from torch import nn
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 from transformers.modeling_outputs import SequenceClassifierOutput
 
 
-class FLDSimpleProver(nn.Module):
+class FLDAllAtOnceProver(nn.Module):
+    """A T5-based prover that generates whole a proof all at once.
+
+       Note that this prover is slightly different from the "step-wise" prover used in paper,
+       which generates a proof step-by-step. This simple prover yields slightly better performance.
+    """
     def __init__(self, pretrained_t5_model: str) -> None:
         super().__init__()
         self.model = T5ForConditionalGeneration.from_pretrained(pretrained_t5_model)

--- a/src/logitorch/pipelines/proof_qa_pipelines.py
+++ b/src/logitorch/pipelines/proof_qa_pipelines.py
@@ -7,12 +7,16 @@ from logitorch.data_collators.proofwriter_collator import (
     ProofWriterProofGenerationAllCollator,
 )
 from logitorch.data_collators.prover_collator import PRoverProofWriterCollator
+from logitorch.data_collators.fld_collator import FLDProofGenerationAllCollator
 from logitorch.datasets.proof_qa.proofwriter_dataset import ProofWriterDataset
+from logitorch.datasets.proof_qa.fld_dataset import FLDDataset
 from logitorch.pipelines.exceptions import ModelNotCompatibleError
 from logitorch.pl_models.proofwriter import PLProofWriter
 from logitorch.pl_models.prover import PLPRover
+from logitorch.pl_models.fld import FLDAllAtOnceProver
 
 PROOFWRITER_COMPATIBLE_MODELS = (PLProofWriter, PLPRover)
+FLD_COMPATIBLE_MODELS = (FLDAllAtOnceProver,)
 
 
 def proofwriter_pipeline(
@@ -68,8 +72,66 @@ def proofwriter_pipeline(
             )
 
             trainer.fit(model, train_dataloader, val_dataloader)
-
         else:
             raise ModelNotCompatibleError(PROOFWRITER_COMPATIBLE_MODELS)
+    except ModelNotCompatibleError as err:
+        print(err.message)
+
+
+def fld_pipeline(
+    model: nn.Module,
+    dataset_name: str,
+    task: str = "proof_generation_all",
+    saved_model_path: str = "/",
+    saved_model_name: str = "best_model",
+    batch_size: int = 4,
+    accum_steps: int = 16,
+    epochs: int = 40,
+    accelerator: str = "cpu",
+    gpus: int = 0,
+):
+    try:
+        if isinstance(model, FLD_COMPATIBLE_MODELS):
+            train_dataset = FLDDataset(
+                dataset_name, "train", task,
+            )
+            val_dataset = FLDDataset(
+                dataset_name, "val", task, max_samples=100,
+            )
+
+            if isinstance(model, FLDAllAtOnceProver):
+                fld_collate_fn = FLDProofGenerationAllCollator(
+                    "t5-base", log_examples=False,
+                )
+            else:
+                raise ValueError()
+
+            train_dataloader = DataLoader(
+                train_dataset, batch_size=batch_size, collate_fn=fld_collate_fn
+            )
+            val_dataloader = DataLoader(
+                val_dataset, batch_size=batch_size, collate_fn=fld_collate_fn
+            )
+
+            checkpoint_callback = ModelCheckpoint(
+                save_top_k=1,
+                monitor="val_loss",
+                mode="min",
+                dirpath=saved_model_path,
+                filename=saved_model_name,
+            )
+
+            trainer = pl.Trainer(
+                callbacks=[checkpoint_callback],
+                auto_lr_find=False,
+                accelerator=accelerator,
+                accumulate_grad_batches=accum_steps,
+                max_epochs=epochs,
+                gpus=gpus,
+            )
+
+            trainer.fit(model, train_dataloader, val_dataloader)
+        else:
+            raise ModelNotCompatibleError(FLD_COMPATIBLE_MODELS)
     except ModelNotCompatibleError as err:
         print(err.message)

--- a/src/logitorch/pl_models/fld.py
+++ b/src/logitorch/pl_models/fld.py
@@ -1,23 +1,22 @@
-from typing import Dict, Tuple, Optional, Union
-import math
+from typing import Dict, Tuple, Optional
 
 import pytorch_lightning as pl
 import torch
-from transformers import Adafactor, get_linear_schedule_with_warmup, AdamW
+from transformers import get_linear_schedule_with_warmup, AdamW
 from transformers.modeling_outputs import SequenceClassifierOutput
-from logitorch.models.fld import FLDSimpleProver
+from logitorch.models.fld import FLDAllAtOnceProver
 
 
-class PLFLDSimpleProver(pl.LightningModule):
+class PLFLDAllAtOnceProver(pl.LightningModule):
     def __init__(
         self,
-        pretrained_model: str = "google/t5-v1_1-large",
+        pretrained_model: str = "t5-base",
         learning_rate: float = None,
         weight_decay=0.1,
         warmup_steps: Optional[int] = 1000,
     ) -> None:
         super().__init__()
-        self.model = FLDSimpleProver(pretrained_model)
+        self.model = FLDAllAtOnceProver(pretrained_model)
         self.pretrained_model = pretrained_model
         self.learning_rate = learning_rate
         self.weight_decay = weight_decay
@@ -45,11 +44,11 @@ class PLFLDSimpleProver(pl.LightningModule):
             weight_decay=self.weight_decay,
         )
 
-        warmup_steps = self.warmup_steps or int(0.1 * self.estimated_stepping_batches)
+        warmup_steps = self.warmup_steps or int(0.1 * self.trainer.estimated_stepping_batches)
         scheduler = get_linear_schedule_with_warmup(
             optimizer,
             num_warmup_steps=warmup_steps,
-            num_training_steps=self.estimated_stepping_batches,
+            num_training_steps=self.trainer.estimated_stepping_batches,
         )
         scheduler = {"scheduler": scheduler, "interval": "step", "frequency": 1}
 
@@ -69,37 +68,3 @@ class PLFLDSimpleProver(pl.LightningModule):
         x, y = val_batch
         loss = self(x, y).loss
         self.log("val_loss", loss, on_epoch=True)
-
-
-    @property
-    def estimated_stepping_batches(self) -> Union[int, float]:
-        """re-implementation of trainer.estimated_stepping_batches as it seems not to correctly calculate the results"""
-        trainer = self.trainer
-        accumulation_scheduler = trainer.accumulation_scheduler
-
-        if accumulation_scheduler.epochs != [0]:
-            raise ValueError(
-                "Estimated stepping batches cannot be computed with different"
-                " `accumulate_grad_batches` at different epochs."
-            )
-
-        # infinite training
-        if trainer.max_epochs == -1 and trainer.max_steps == -1:
-            return float("inf")
-
-        if trainer.train_dataloader is None:
-            # rank_zero_info("Loading `train_dataloader` to estimate number of stepping batches.")
-            trainer.reset_train_dataloader()
-
-        total_batches = trainer.num_training_batches
-
-        # iterable dataset
-        if total_batches == float("inf"):
-            return trainer.max_steps
-
-        trainer.accumulate_grad_batches = accumulation_scheduler.get_accumulate_grad_batches(trainer.current_epoch)
-        effective_batch_size = trainer.accumulate_grad_batches
-        max_estimated_steps = math.ceil(total_batches / effective_batch_size) * max(trainer.max_epochs, 1)
-
-        max_estimated_steps = max(max_estimated_steps, trainer.max_steps) if trainer.max_steps != -1 else max_estimated_steps
-        return max_estimated_steps

--- a/src/logitorch/pl_models/fld.py
+++ b/src/logitorch/pl_models/fld.py
@@ -1,0 +1,105 @@
+from typing import Dict, Tuple, Optional, Union
+import math
+
+import pytorch_lightning as pl
+import torch
+from transformers import Adafactor, get_linear_schedule_with_warmup, AdamW
+from transformers.modeling_outputs import SequenceClassifierOutput
+from logitorch.models.fld import FLDSimpleProver
+
+
+class PLFLDSimpleProver(pl.LightningModule):
+    def __init__(
+        self,
+        pretrained_model: str = "google/t5-v1_1-large",
+        learning_rate: float = None,
+        weight_decay=0.1,
+        warmup_steps: Optional[int] = 1000,
+    ) -> None:
+        super().__init__()
+        self.model = FLDSimpleProver(pretrained_model)
+        self.pretrained_model = pretrained_model
+        self.learning_rate = learning_rate
+        self.weight_decay = weight_decay
+        self.warmup_steps = warmup_steps
+
+        self.optimizer = None
+
+    def forward(self, x, y) -> SequenceClassifierOutput:  # type: ignore
+        return self.model(x, y)
+
+    def predict(
+        self,
+        prompt: str,
+        num_beams: int = 5,
+        max_length: int = 1000,
+        device: str = "cpu",
+    ):
+        return self.model.predict(prompt, num_beams, max_length, device)
+
+    def configure_optimizers(self):
+
+        optimizer = AdamW(
+            self.model.parameters(),
+            lr=self.learning_rate,
+            weight_decay=self.weight_decay,
+        )
+
+        warmup_steps = self.warmup_steps or int(0.1 * self.estimated_stepping_batches)
+        scheduler = get_linear_schedule_with_warmup(
+            optimizer,
+            num_warmup_steps=warmup_steps,
+            num_training_steps=self.estimated_stepping_batches,
+        )
+        scheduler = {"scheduler": scheduler, "interval": "step", "frequency": 1}
+
+        self.optimizer = optimizer
+        return [optimizer], [scheduler]
+
+    def training_step(self, train_batch: Tuple[Dict[str, torch.Tensor], torch.Tensor], batch_idx: int) -> torch.Tensor:  # type: ignore
+        x, y = train_batch
+        loss = self(x, y).loss
+        self.log("train_loss", loss, on_step=True)
+
+        for param_group in self.optimizer.param_groups:
+            print("Current learning rate is: {}".format(param_group['lr']))
+        return loss
+
+    def validation_step(self, val_batch: Tuple[Dict[str, torch.Tensor], torch.Tensor], batch_idx: int) -> None:  # type: ignore
+        x, y = val_batch
+        loss = self(x, y).loss
+        self.log("val_loss", loss, on_epoch=True)
+
+
+    @property
+    def estimated_stepping_batches(self) -> Union[int, float]:
+        """re-implementation of trainer.estimated_stepping_batches as it seems not to correctly calculate the results"""
+        trainer = self.trainer
+        accumulation_scheduler = trainer.accumulation_scheduler
+
+        if accumulation_scheduler.epochs != [0]:
+            raise ValueError(
+                "Estimated stepping batches cannot be computed with different"
+                " `accumulate_grad_batches` at different epochs."
+            )
+
+        # infinite training
+        if trainer.max_epochs == -1 and trainer.max_steps == -1:
+            return float("inf")
+
+        if trainer.train_dataloader is None:
+            # rank_zero_info("Loading `train_dataloader` to estimate number of stepping batches.")
+            trainer.reset_train_dataloader()
+
+        total_batches = trainer.num_training_batches
+
+        # iterable dataset
+        if total_batches == float("inf"):
+            return trainer.max_steps
+
+        trainer.accumulate_grad_batches = accumulation_scheduler.get_accumulate_grad_batches(trainer.current_epoch)
+        effective_batch_size = trainer.accumulate_grad_batches
+        max_estimated_steps = math.ceil(total_batches / effective_batch_size) * max(trainer.max_epochs, 1)
+
+        max_estimated_steps = max(max_estimated_steps, trainer.max_steps) if trainer.max_steps != -1 else max_estimated_steps
+        return max_estimated_steps


### PR DESCRIPTION
Hi LogiTorch Developers,

Thanks for such a great framework. We are currently using LogiTorch, which significantly helps us accelerate research experiments.

We have been working on our dataset FLD, which was proposed in our ICML 2023 paper "Learning Deductive Reasoning from Synthetic Corpus based on Formal Logic" (https://proceedings.mlr.press/v202/morishita23a.html).
Could it be possible to add FLD to LogiTorch?

We have implemented all the elements, i.e., the dataset and the collator, the model, the pipeline, and the training and evaluation scripts.
We have tested that the training succeeds by training_examples.py, and the model performs well by eval_examples.py.

Best,
Terufumi Morishita